### PR TITLE
Double buffering trouble

### DIFF
--- a/examples/color_changing_rect_menu.rs
+++ b/examples/color_changing_rect_menu.rs
@@ -3,15 +3,15 @@ use knukki::*;
 fn main() {
     let mut menu = SimpleFlatMenu::new(Some(Color::rgb(50, 150, 100)));
     menu.add_component(
-        Box::new(ColorChangingRectComponent { red: 200, green: 100, blue: 0 }),
+        Box::new(ColorChangingRectComponent { red: 200, green: 100, blue: 0, id: 1 }),
         ComponentDomain::between(0.1, 0.1, 0.8, 0.4)
     );
     menu.add_component(
-        Box::new(ColorChangingRectComponent { red: 50, green: 200, blue: 150 }),
+        Box::new(ColorChangingRectComponent { red: 50, green: 200, blue: 150, id: 2 }),
         ComponentDomain::between(0.5, 0.5, 0.9, 0.9)
     );
     menu.add_component(
-        Box::new(ColorChangingRectComponent { red: 200, green: 0, blue: 150 }),
+        Box::new(ColorChangingRectComponent { red: 200, green: 0, blue: 150, id: 3 }),
         ComponentDomain::between(0.05, 0.7, 0.4, 0.95)
     );
     let application = Application::new(Box::new(menu));
@@ -22,7 +22,9 @@ struct ColorChangingRectComponent {
 
     red: u8,
     green: u8,
-    blue: u8
+    blue: u8,
+
+    id: u8
 }
 
 impl Component for ColorChangingRectComponent {

--- a/examples/color_changing_rect_menu.rs
+++ b/examples/color_changing_rect_menu.rs
@@ -1,7 +1,7 @@
 use knukki::*;
 
 fn main() {
-    let mut menu = SimpleFlatMenu::new(Some(Color::rgb(50, 150, 100)));
+    let mut menu = SimpleFlatMenu::new(Some(Color::rgb(0, 0, 0)));
     menu.add_component(
         Box::new(ColorChangingRectComponent { red: 200, green: 100, blue: 0, id: 1 }),
         ComponentDomain::between(0.1, 0.1, 0.8, 0.4)

--- a/examples/color_changing_rect_menu.rs
+++ b/examples/color_changing_rect_menu.rs
@@ -1,17 +1,17 @@
 use knukki::*;
 
 fn main() {
-    let mut menu = SimpleFlatMenu::new(Some(Color::rgb(0, 0, 0)));
+    let mut menu = SimpleFlatMenu::new(Some(Color::rgb(50, 150, 100)));
     menu.add_component(
-        Box::new(ColorChangingRectComponent { red: 200, green: 100, blue: 0, id: 1 }),
+        Box::new(ColorChangingRectComponent { red: 200, green: 100, blue: 0 }),
         ComponentDomain::between(0.1, 0.1, 0.8, 0.4)
     );
     menu.add_component(
-        Box::new(ColorChangingRectComponent { red: 50, green: 200, blue: 150, id: 2 }),
+        Box::new(ColorChangingRectComponent { red: 50, green: 200, blue: 150 }),
         ComponentDomain::between(0.5, 0.5, 0.9, 0.9)
     );
     menu.add_component(
-        Box::new(ColorChangingRectComponent { red: 200, green: 0, blue: 150, id: 3 }),
+        Box::new(ColorChangingRectComponent { red: 200, green: 0, blue: 150 }),
         ComponentDomain::between(0.05, 0.7, 0.4, 0.95)
     );
     let application = Application::new(Box::new(menu));
@@ -23,8 +23,6 @@ struct ColorChangingRectComponent {
     red: u8,
     green: u8,
     blue: u8,
-
-    id: u8
 }
 
 impl Component for ColorChangingRectComponent {

--- a/src/provider/desktop.rs
+++ b/src/provider/desktop.rs
@@ -60,7 +60,6 @@ pub fn start(mut app: Application, title: &str) {
                 match window_event {
                     WindowEvent::Resized(_) => {
                         // TODO app.on_resize
-                        println!("Resize");
                         render_surface = None;
                     }
                     WindowEvent::MouseInput {
@@ -214,37 +213,18 @@ pub fn start(mut app: Application, title: &str) {
             render_texture.set_image(None, size.width, size.height, ColorFormat::RGBA);
             *render_surface = Some(Surface::new(golem, render_texture).expect("Should be able to create surface"));
             created_surface = true;
+            render_surface.as_ref().unwrap().bind();
         }
 
         // Draw the application on the render texture
         let render_surface = render_surface.as_ref().unwrap();
-        if !render_surface.is_bound() {
-            render_surface.bind();
-            println!("Bind render surface");
-        }
         if app.render(renderer, region, force || created_surface) {
-            println!("Expected pixels:");
-            let mut pixel_data = vec![0; 4 * size.width as usize * size.height as usize];
-            render_surface.get_pixel_data(0, 0, size.width, size.height, ColorFormat::RGBA, &mut pixel_data);
-            let mut y = 0;
-            while y < size.height {
-                let mut x = 0;
-                while x < size.width {
-                    let index = 4 * (x + y * size.width) as usize;
-                    print!("{}{}{} ", pixel_data[index + 0] / 26, pixel_data[index + 1] / 26, pixel_data[index + 2] / 26);
-                    x += 30;
-                }
-                y += 30;
-                println!();
-            }
-            println!();
-            println!();
 
             // Draw the render texture onto the presenting texture
-            println!("Unbind render surface");
             Surface::unbind(renderer.get_context());
             golem.set_viewport(0, 0, size.width, size.height);
             golem.disable_scissor();
+
             // TODO Improve performance by creating the GPU resources only once
             let mut vb = VertexBuffer::new(golem)?;
             let mut eb = ElementBuffer::new(golem)?;
@@ -293,6 +273,8 @@ pub fn start(mut app: Application, title: &str) {
             }
 
             windowed_context.swap_buffers().expect("Good context");
+
+            render_surface.bind();
         }
         Ok(())
     }


### PR DESCRIPTION
Today, I tested one of the examples on my other laptop, and that didn't go so well, because this other laptop uses double buffering.

The knukki rendering system is based on the draw-when-needed principle. The problem is that this caused the front buffer and back buffer to have different content, which caused weird visual glitches. This pull request solves this by ensuring that the desktop provider will always draw the application onto a separate buffer, rather than the default render target. Whenever anything changes, we copy that buffer to the real render target.